### PR TITLE
Fix to Python 3 ASCII encoding error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN     update-alternatives --install "/usr/bin/go" "go" "/usr/lib/go-1.9/bin/go
 
 COPY	run.sh /
 COPY	sudoers /etc
+COPY    utf-8.sh /etc/profile.d
 
 RUN	chmod +x ./run.sh
 

--- a/utf-8.sh
+++ b/utf-8.sh
@@ -1,0 +1,2 @@
+export LC_ALL=C.UTF-8
+export LANG=C.UTF-8


### PR DESCRIPTION
I have added var env to setup LC_ALL and LANG to C.UTF-8 to fix the follow error.
```
RuntimeError: Click will abort further execution because Python 3 was configured to use ASCII as encoding for the environment.  Either run this under Python 2 or consult http://click.pocoo.org/python3/ for mitigation steps.

This system supports the C.UTF-8 locale which is recommended.
You might be able to resolve your issue by exporting the
following environment variables:

    export LC_ALL=C.UTF-8
    export LANG=C.UTF-8

```